### PR TITLE
Ensure streak recording uses date-only strings

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -180,7 +180,7 @@ async def main() -> None:
             return
 
         # Record the streak for the user
-        today = datetime.now(ZoneInfo("America/New_York")).isoformat()
+        today = datetime.now(ZoneInfo("America/New_York")).date().isoformat()
         user_id = str(message.author.id)
         streak_count = await streak_manager.record_streak(guild_id, user_id, today)
 


### PR DESCRIPTION
## Summary
- Ensure streak recording uses `YYYY-MM-DD` by calling `.date().isoformat()`
- Confirm `StreakManager.record_streak` expects a date-only string

## Testing
- `python -m py_compile bot.py streak_manager.py`
- `python - <<'PY'
import asyncio, tempfile, os
from streak_manager import StreakManager

async def main():
    tmp = tempfile.NamedTemporaryFile(delete=False)
    tmp.close()
    mgr = StreakManager(tmp.name)
    await mgr.ensure_guild('123')
    res1 = await mgr.record_streak('123','u','2024-05-01')
    res2 = await mgr.record_streak('123','u','2024-05-01')
    res3 = await mgr.record_streak('123','u','2024-05-02')
    print('streaks', res1, res2, res3)
    print('stored last_date', mgr._data['guilds']['123']['users']['u']['last_date'])

asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_688fd0a928d08320ac4b5703b68d34d1